### PR TITLE
build(gha): updated docker image ci with latest

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -29,4 +29,6 @@ jobs:
           context: .
           file: Dockerfile
           push: true
-          tags: ${{ env.ORG }}/metadata-enhancer:${{ github.ref_name }}
+          tags: |
+            ${{ env.ORG }}/metadata-enhancer:${{ github.ref_name }}
+            ${{ env.ORG }}/metadata-enhancer:latest


### PR DESCRIPTION
The change expands the ci by having a second tag be created called `:latest` for each tag push.