### PR TITLE
fix(cbs): handle list alternativeTitle and update frequency TSV URL

### DIFF
--- a/dot_env_example
+++ b/dot_env_example
@@ -6,7 +6,7 @@ APPLICATION_DIR=src
 # URL'S
 ELSST_FUSEKI_URL='https://fuseki.devstack.odissei.nl/skosmos/sparql'
 VARIABLE_FUSEKI_URL='https://fuseki.devstack.odissei.nl/skosmos/sparql'
-GITHUB_RAW_URL="https://raw.githubusercontent.com/Dans-labs/semantic-enrichment/master/static/alle-beschikbare-catalogus-bestanden.tsv"
+GITHUB_RAW_URL="https://raw.githubusercontent.com/odissei-data/semantic-enrichment/refs/heads/main/alle-beschikbare-catalogus-bestanden.tsv"
 
 CBS_VOCAB_URL=https://vocabs.cbs.nl
 ELSST_VOCAB_URL=https://thesauri.cessda.eu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metadata-enhancer"
-version = "3.0.0"
+version = "3.0.1"
 description = "A service that enriches metadata using controlled vocabularies."
 authors = ["Fjodor van Rijsselberg"]
 include = ["src"]

--- a/src/enhancers/FrequencyEnhancer.py
+++ b/src/enhancers/FrequencyEnhancer.py
@@ -16,10 +16,19 @@ class FrequencyEnhancer(MetadataEnhancer):
         frequency of use as the value. If a match is found the frequency
         of use is added to the enrichments metadata block.
         """
-        alternative_title = self.get_value_from_metadata(
+        alternative_titles = self.get_value_from_metadata(
             metadata_field_name='alternativeTitle',
             metadata_block='citation'
-        )[0]
+        )
+        if not alternative_titles:
+            return
+        alternative_title = alternative_titles[0]
+        if isinstance(alternative_title, list):
+            if not alternative_title:
+                return
+            alternative_title = alternative_title[0]
+        if not isinstance(alternative_title, str):
+            return
         frequency_of_use = self.query_enrichment_table(alternative_title)
         if frequency_of_use:
             self.add_enhancement_to_primitive_metadata_field('frequencyOfUse',


### PR DESCRIPTION
## Summary
- Fix TypeError when `alternativeTitle` is a list instead of a string in FrequencyEnhancer
- Update `dot_env_example` GITHUB_RAW_URL to new odissei-data/semantic-enrichment repo

## Related
ODSP-329